### PR TITLE
Add blueprint generator for frosty acceptance-test

### DIFF
--- a/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
+++ b/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
@@ -1,0 +1,32 @@
+import {expect} from 'chai'
+import {afterEach, beforeEach, describe, it} from 'mocha'
+
+import destroyApp from '../helpers/destroy-app'
+import startApp from '../helpers/start-app'
+
+describe('<%= friendlyTestName %>', function () {
+  let application
+
+  beforeEach(function () {
+    application = startApp()
+  })
+
+  afterEach(function () {
+    destroyApp(application)
+    application = null
+  })
+
+  it('should have real tests', function () {
+    expect(false).to.equal(true)
+  })
+
+  describe('when visiting /<%= dasherizedModuleName %>', function () {
+    beforeEach(function () {
+      return visit('/<%= dasherizedModuleName %>')
+    })
+
+    it('should have the proper URL', function () {
+      expect(currentURL()).to.equal('/<%= dasherizedModuleName %>')
+    })
+  })
+})

--- a/blueprints/acceptance-test/index.js
+++ b/blueprints/acceptance-test/index.js
@@ -1,0 +1,29 @@
+/**
+ * Blueprint for generating an acceptance test for a feature in a frosty app/addon
+ * NOTE: this is run in node, not in ember stack, so limited es6 is available
+ * Taken primarily from
+ * https://github.com/ember-cli/ember-cli-legacy-blueprints/blob/v0.1.4/blueprints/acceptance-test/index.js
+ * and updated to use our styles and assume mocha (no need to support qunit)
+ */
+
+const testInfo = require('ember-cli-test-info')
+const pathUtil = require('ember-cli-path-utils')
+const stringUtils = require('ember-cli-string-utils')
+
+module.exports = {
+  description: 'Generates a frosty acceptance test for a feature.',
+
+  locals (options) {
+    let testFolderRoot = stringUtils.dasherize(options.project.name())
+
+    if (options.project.isEmberCLIAddon()) {
+      testFolderRoot = pathUtil.getRelativeParentPath(options.entity.name, -1, false)
+    }
+
+    const humanizedName = testInfo.humanize(options.entity.name)
+    return {
+      friendlyTestName: `Acceptance / ${humanizedName} /`,
+      testFolderRoot
+    }
+  }
+}

--- a/tests/acceptance-test.js
+++ b/tests/acceptance-test.js
@@ -1,0 +1,11 @@
+/**
+ * Mocha test for the acceptance test blueprints
+ */
+
+'use strict'
+
+const itShouldGenerateCorrectly = require('./utils').itShouldGenerateCorrectly
+
+itShouldGenerateCorrectly('acceptance-test', [
+  'foo-bar'
+])

--- a/tests/acceptance/.eslintrc.js
+++ b/tests/acceptance/.eslintrc.js
@@ -1,0 +1,17 @@
+module.exports = {
+  // Call out the globally exposed acceptance test helpers
+  globals: {
+    andThen: false,
+    click: false,
+    currentPath: false,
+    currentRouteName: false,
+    currentURL: false,
+    find: false,
+    fillIn: false,
+    keyEvent: false,
+    server: false,
+    triggerEvent: false,
+    visit: false,
+    waitForPromise: false
+  }
+}


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [x] #major# - incompatible API change


This is not technically a major, but I want to get us on 1.x

# CHANGELOG

* **Added** `acceptance-test` blueprint (resolves [#7](https://github.com/ciena-frost/ember-cli-frost-blueprints/issues/7))
