### PR TITLE
Upgrade to Ember CLI 2.15.1

### DIFF
--- a/blueprints/controller/files/__root__/__path__/__name__.js
+++ b/blueprints/controller/files/__root__/__path__/__name__.js
@@ -2,8 +2,7 @@
  * Controller definition for the <%= dasherizedModuleName %> controller
  */
 
-import Ember from 'ember'
-const {Controller} = Ember
+import Controller from '@ember/controller'
 
 export default Controller.extend({
 })

--- a/blueprints/helper/files/__root__/helpers/__name__.js
+++ b/blueprints/helper/files/__root__/helpers/__name__.js
@@ -1,11 +1,11 @@
 /**
  * Helper definition for the <%= dasherizedModuleName %> helper
  */
-import Ember from 'ember'
-const {Helper} = Ember
+
+import {helper} from '@ember/component/helper'
 
 export function <%= camelizedModuleName %> (params/*, hash*/) {
   return params
 }
 
-export default Helper.helper(<%= camelizedModuleName %>)
+export default helper(<%= camelizedModuleName %>)

--- a/blueprints/mixin-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/mixin-test/files/tests/unit/__path__/__test__.js
@@ -2,8 +2,8 @@
  * Unit test for the <%= dasherizedModuleName %> mixin
  */
 
+import EmberObject from '@ember/object'
 import {expect} from 'chai'
-import Ember from 'ember'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
@@ -14,7 +14,7 @@ describe('Unit / Mixin / <%= dasherizedModuleName %> /', function () {
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create()
-    subject = Ember.Object.extend(<%= classifiedModuleName %>Mixin).create()
+    subject = EmberObject.extend(<%= classifiedModuleName %>Mixin).create()
   })
 
   afterEach(function () {

--- a/blueprints/mixin/files/__root__/mixins/__name__.js
+++ b/blueprints/mixin/files/__root__/mixins/__name__.js
@@ -1,8 +1,8 @@
 /**
  * Mixin definition for the <%= dasherizedModuleName %> mixin
  */
-import Ember from 'ember'
-const {Mixin} = Ember
+
+import Mixin from '@ember/object/mixin'
 
 export default Mixin.create({
 })

--- a/blueprints/service/files/__root__/__path__/__name__.js
+++ b/blueprints/service/files/__root__/__path__/__name__.js
@@ -2,8 +2,7 @@
  * Service definition for the <%= dasherizedModuleName %> service
  */
 
-import Ember from 'ember'
-const {Service} = Ember
+import Service from '@ember/service'
 
 export default Service.extend({
 })

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,8 +1,9 @@
 /* eslint-env node */
+'use strict'
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon')
 
 module.exports = function (defaults) {
-  var app = new EmberAddon(defaults, {
+  let app = new EmberAddon(defaults, {
   })
 
   return app.toTree()

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "chalk": "^1.1.3",
-    "ember-cli": "2.12.3",
+    "ember-cli": "2.15.1",
     "ember-test-utils": "^5.0.0",
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0"


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [X] #major# - incompatible API change

# CHANGELOG
* **Updated** to Ember CLI 2.15.1
* **Updated** blueprints to Ember Javascript Modules API (https://github.com/emberjs/rfcs/blob/master/text/0176-javascript-module-api.md)